### PR TITLE
Updated get_default_config() to check if username and/or password are present on the command line

### DIFF
--- a/jenkins_autojobs/main.py
+++ b/jenkins_autojobs/main.py
@@ -1,4 +1,3 @@
-
 import re
 import yaml
 
@@ -152,8 +151,8 @@ def get_default_config(config, opts):
     if '-d' in o: c['debug'] = True
 
     # jenkins authentication options
-    c['username'] = o.get('-u', None)
-    c['password'] = o.get('-p', None)
+    if '-u' in o: c['username'] = o.get('-u', None)
+    if '-p' in o: c['password'] = o.get('-p', None)
 
     c['scm-username'] = c.get('scm-username', None) #:todo
     c['scm-password'] = c.get('scm-password', None) #:todo


### PR DESCRIPTION
Username and password can be set in the configuration yaml file, and can be overwritten using the command line. Without this fix, it would always use the command line username/password combination, which would make the config file options useless.

Apparently the previous PR got lost, maybe due to a force push?
