### PR TITLE
Compatibility with mercurial plugin 1.50, filtering hg branches by age

### DIFF
--- a/jenkins_autojobs/hg.py
+++ b/jenkins_autojobs/hg.py
@@ -96,9 +96,11 @@ def create_job(ref, template, config, ref_config):
         msg = 'Template job %s is not configured to use Mercurial as an SCM'
         raise RuntimeError(msg % template)  # :bug:
 
-    # set branch
-    el = scm_el.xpath('//branch')[0]
-    el.text = ref
+    # set branch 
+    el = scm_el.xpath('//branch')
+    if not el:
+        el = scm_el.xpath('//revision')    
+    el[0].text = ref
 
     # set the state of the newly created job
     job.set_state(ref_config['enable'])


### PR DESCRIPTION
Hi

The mercurial plugin v1.50 stores the branch in a different place, my fix should work for both versions
Also, I needed a way for ignore old branches and added a 'maxbranchage' field to the yaml file which specifies the max allowed age of the last commit to any branch in days. Set to 0 to get all branches.