### PR TITLE
fix 'sticky' job state

### DIFF
--- a/jenkins_autojobs/job.py
+++ b/jenkins_autojobs/job.py
@@ -40,6 +40,8 @@ class Job(object):
         elif value == 'sticky' and self.config:
             if '<disabled>false</disabled>' in self.config:
                 el.text = 'false'
+            else:
+                el.text = 'true'
 
     def substitute(self, items, fmtdict, groups, groupdict):
         for el in self.xml.xpath("//text()"):


### PR DESCRIPTION
When the "enable" config option is set to 'sticky', disabled jobs should stay disabled.