### PR TITLE
new parameters introduced: add_origin and use_local_branch

### DIFF
--- a/jenkins_autojobs/git.py
+++ b/jenkins_autojobs/git.py
@@ -99,13 +99,16 @@ def create_job(ref, template, config, ref_config):
     el = scm_el.xpath('//hudson.plugins.git.BranchSpec/name')[0]
     # :todo: jenkins is being very capricious about the branch-spec
     # el.text = '%s/%s' % (remote, shortref)  # :todo:
-    el.text = shortref
+    if config["add_origin"]:
+        el.text = '%s/%s' % ("origin", shortref)
+    else:
+        el.text = shortref
 
     # Set the branch that the git plugin will locally checkout to.
-    el = scm_el.xpath('//localBranch')
-    el = etree.SubElement(scm_el, 'localBranch') if not el else el[0]
-
-    el.text = shortref  # the original shortref (with '/')
+    if config["use_local_branch"]:
+        el = scm_el.xpath('//localBranch')
+        el = etree.SubElement(scm_el, 'localBranch') if not el else el[0]
+        el.text = shortref  # the original shortref (with '/')
 
     # Set the state of the newly created job.
     job.set_state(ref_config['enable'])

--- a/jenkins_autojobs/git.py
+++ b/jenkins_autojobs/git.py
@@ -105,7 +105,9 @@ def create_job(ref, template, config, ref_config):
         el.text = shortref
 
     # Set the branch that the git plugin will locally checkout to.
-    if config["use_local_branch"]:
+
+
+    if (not config.has_key("use_local_branch")) or config["use_local_branch"]:
         el = scm_el.xpath('//localBranch')
         el = etree.SubElement(scm_el, 'localBranch') if not el else el[0]
         el.text = shortref  # the original shortref (with '/')


### PR DESCRIPTION
As discussed in the issue https://github.com/gvalkov/jenkins-autojobs/issues/40
The user has the possibility to add 'add_origin' and 'use_local_branch' parameter in the yaml configuration file.