### PR TITLE
Build on create feature.

### DIFF
--- a/doc/examples/git-config.yaml
+++ b/doc/examples/git-config.yaml
@@ -59,6 +59,11 @@ namefmt: '{shortref}'
 overwrite: true
 
 #-----------------------------------------------------------------------------
+# If true, a job will be added to build queue when it is created.
+# If false, a job will be only created (the default).
+build-on-create: false
+
+#-----------------------------------------------------------------------------
 # State of newly created or overwritten jobs. Default is 'sticky'. One of:
 #   true       -> Jobs will be enabled.
 #   false      -> Jobs will be disabled.

--- a/doc/examples/git-config.yaml.jinja2
+++ b/doc/examples/git-config.yaml.jinja2
@@ -45,6 +45,8 @@ namefmt: '{shortref}'
 
 {{ m.overwrite()|trim }}
 
+{{ m.build_on_create()|trim }}
+
 {{ m.enable()|trim }}
 
 {{ m.substitute()|trim }}

--- a/doc/examples/hg-config.yaml
+++ b/doc/examples/hg-config.yaml
@@ -61,6 +61,11 @@ namefmt: '{branch}'
 overwrite: true
 
 #-----------------------------------------------------------------------------
+# If true, a job will be added to build queue when it is created.
+# If false, a job will be only created (the default).
+build-on-create: false
+
+#-----------------------------------------------------------------------------
 # State of newly created or overwritten jobs. Default is 'sticky'. One of:
 #   true       -> Jobs will be enabled.
 #   false      -> Jobs will be disabled.

--- a/doc/examples/hg-config.yaml.jinja2
+++ b/doc/examples/hg-config.yaml.jinja2
@@ -47,6 +47,8 @@ namefmt: '{branch}'
 
 {{ m.overwrite()|trim }}
 
+{{ m.build_on_create()|trim }}
+
 {{ m.enable()|trim }}
 
 {{ m.substitute()|trim }}

--- a/doc/examples/shared-config.jinja2
+++ b/doc/examples/shared-config.jinja2
@@ -33,6 +33,13 @@ template: new-job-template
 overwrite: true
 {% endmacro %}
 
+{% macro build_on_create() %}
+#-----------------------------------------------------------------------------
+# If true, a job will be added to build queue when it is created.
+# If false, a job will be only created (the default).
+build-on-create: false
+{% endmacro %}
+
 {% macro enable() %}
 #-----------------------------------------------------------------------------
 # State of newly created or overwritten jobs. Default is 'sticky'. One of:

--- a/doc/examples/svn-config.yaml
+++ b/doc/examples/svn-config.yaml
@@ -55,6 +55,11 @@ namefmt: '{path}'
 overwrite: true
 
 #-----------------------------------------------------------------------------
+# If true, a job will be added to build queue when it is created.
+# If false, a job will be only created (the default).
+build-on-create: false
+
+#-----------------------------------------------------------------------------
 # State of newly created or overwritten jobs. Default is 'sticky'. One of:
 #   true       -> Jobs will be enabled.
 #   false      -> Jobs will be disabled.

--- a/doc/examples/svn-config.yaml.jinja2
+++ b/doc/examples/svn-config.yaml.jinja2
@@ -41,6 +41,8 @@ namefmt: '{path}'
 
 {{ m.overwrite()|trim }}
 
+{{ m.build_on_create()|trim }}
+
 {{ m.enable()|trim }}
 
 {{ m.substitute()|trim }}

--- a/jenkins_autojobs/git.py
+++ b/jenkins_autojobs/git.py
@@ -114,7 +114,7 @@ def create_job(ref, template, config, ref_config):
     # job name, we do it for them.
     job.substitute(list(ref_config['substitute'].items()), fmtdict, groups, groupdict)
 
-    job.create(ref_config['overwrite'], config['dryrun'], tag=ref_config['tag'])
+    job.create(ref_config['overwrite'], ref_config['build-on-create'], config['dryrun'], tag=ref_config['tag'])
 
     if config['debug']:
         debug_refconfig(ref_config)

--- a/jenkins_autojobs/hg.py
+++ b/jenkins_autojobs/hg.py
@@ -112,7 +112,7 @@ def create_job(ref, template, config, ref_config):
     # job name, we do it for them.
     job.substitute(list(ref_config['substitute'].items()), fmtdict, groups, groupdict)
 
-    job.create(ref_config['overwrite'], config['dryrun'])
+    job.create(ref_config['overwrite'], ref_config['build-on-create'], config['dryrun'])
 
     if config['debug']:
         debug_refconfig(ref_config)

--- a/jenkins_autojobs/job.py
+++ b/jenkins_autojobs/job.py
@@ -61,7 +61,7 @@ class Job(object):
             # nobody makes a non-semantic change ...
             return etree.tostring(xml)
 
-    def create(self, overwrite, dryrun, tag=None):
+    def create(self, overwrite, build_on_create, dryrun, tag=None):
         # Append autojobs-information.
         info_el = etree.SubElement(self.xml, 'createdByJenkinsAutojobs')
         ref_el  = etree.SubElement(info_el, 'ref')
@@ -91,6 +91,12 @@ class Job(object):
             if not dryrun:
                 self.jenkins.job_create(self.name, self.xml)
             print('. job created')
+
+            # Build newly created job.
+            if build_on_create:
+                if not dryrun:
+                    self.jenkins.job_build(self.name)
+                print('. job ')
 
         elif not overwrite:
             print('. overwrite disabled - skipping job')

--- a/jenkins_autojobs/main.py
+++ b/jenkins_autojobs/main.py
@@ -226,15 +226,16 @@ def get_default_config(config, opts):
 
     # Default settings for each git ref/branch/ config.
     c['defaults'] = {
-        'namesep':    c.get('namesep', '-'),
-        'namefmt':    c.get('namefmt', '{shortref}'),
-        'overwrite':  c.get('overwrite', True),
-        'enable':     c.get('enable', 'sticky'),
-        'substitute': c.get('substitute', {}),
-        'template':   c.get('template'),
-        'sanitize':   c.get('sanitize', {'@!?#&|\^_$%*': '_'}),
-        'tag':        c.get('tag', []),
-        'view':       c.get('view', [])
+        'namesep':         c.get('namesep', '-'),
+        'namefmt':         c.get('namefmt', '{shortref}'),
+        'overwrite':       c.get('overwrite', True),
+        'enable':          c.get('enable', 'sticky'),
+        'substitute':      c.get('substitute', {}),
+        'template':        c.get('template'),
+        'sanitize':        c.get('sanitize', {'@!?#&|\^_$%*': '_'}),
+        'tag':             c.get('tag', []),
+        'view':            c.get('view', []),
+        'build-on-create': c.get('build-on-create', False)
     }
 
     # Make sure some options are always lists.

--- a/jenkins_autojobs/svn.py
+++ b/jenkins_autojobs/svn.py
@@ -118,7 +118,7 @@ def create_job(branch, template, config, branch_config):
     # job name, we do it for them.
     job.substitute(list(branch_config['substitute'].items()), fmtdict, groups, groupdict)
 
-    job.create(branch_config['overwrite'], config['dryrun'], tag=branch_config['tag'])
+    job.create(branch_config['overwrite'], branch_config['build-on-create'], config['dryrun'], tag=branch_config['tag'])
 
     if config['debug']:
         debug_refconfig(branch_config)


### PR DESCRIPTION
Added support for building newly created jobs.

By adding parameter `build-on-create` in the YAML file all newly created jobs will be automatically added to the build queue. By default this value is set to `false`.