### PR TITLE
Fixed `NameError: global name 'abspath' is not defined`

### DIFF
--- a/jenkins_autojobs/main.py
+++ b/jenkins_autojobs/main.py
@@ -92,7 +92,7 @@ def main(argv, create_job, list_branches, getoptfmt='vdtnr:j:u:p:y:o:UPYO', conf
     # Load config, set default values and compile regexes.
     if not config:
         yamlfn = args[-1]
-        print('loading config from "%s"' % abspath(yamlfn))
+        print('loading config from "%s"' % os.path.abspath(yamlfn))
         config = yaml.load(open(yamlfn))
 
     config = c = get_default_config(config, opts)


### PR DESCRIPTION
Recently I've got this error:
```
Traceback (most recent call last):
  File "/Users/bjanda/.pyenv/versions/t/bin/jenkins-makejobs-git", line 9, in <module>
    load_entry_point('jenkins-autojobs==0.16.1', 'console_scripts', 'jenkins-makejobs-git')()
  File "/Users/bjanda/Downloads/OtherProjects/jenkins-autojobs/jenkins_autojobs/git.py", line 129, in _main
    main.main(argv[1:], config=config, create_job=create_job, list_branches=list_branches)
  File "/Users/bjanda/Downloads/OtherProjects/jenkins-autojobs/jenkins_autojobs/main.py", line 95, in main
    print('loading config from "%s"' % abspath(yamlfn))
NameError: global name 'abspath' is not defined
```

There is missing import or path to function. Please can you fix (merge) it ASAP. 