### PR TITLE
Added a `cleanup-filters` feature

### DIFF
--- a/docs/examples/git-config.yaml
+++ b/docs/examples/git-config.yaml
@@ -136,6 +136,19 @@ tag: 'throw-away-jobs'
 cleanup: true  # or 'throw-away-jobs'
 
 #-----------------------------------------------------------------------------
+# Filter jobs by views and job names. By default all jobs are checked if they
+# should be removed. To reduce time you can filter which jobs should be
+# checked. You can use:
+# 1. List of views, by default jobs from all views are taken.
+# 2. List of job names as regular expressions, by default all jobs will be
+# taken.
+cleanup-filters:
+  views:
+    - 'My View'
+  jobs:
+    - '.*'
+
+#-----------------------------------------------------------------------------
 # Method for writing tags and marking the build as created by jenkins-autojobs.
 #   'description' -> add special strings to the job's description (default).
 #   'element'     -> add new xml elements to the job's config.xml.

--- a/docs/examples/git-config.yaml.jinja2
+++ b/docs/examples/git-config.yaml.jinja2
@@ -84,4 +84,6 @@ refs:
 
 {{ m.cleanup()|trim }}
 
+{{ m.cleanup_filter()|trim }}
+
 {{ m.tag_method()|trim }}

--- a/docs/examples/hg-config.yaml
+++ b/docs/examples/hg-config.yaml
@@ -132,6 +132,19 @@ tag: 'throw-away-jobs'
 cleanup: true  # or 'throw-away-jobs'
 
 #-----------------------------------------------------------------------------
+# Filter jobs by views and job names. By default all jobs are checked if they
+# should be removed. To reduce time you can filter which jobs should be
+# checked. You can use:
+# 1. List of views, by default jobs from all views are taken.
+# 2. List of job names as regular expressions, by default all jobs will be
+# taken.
+cleanup-filters:
+  views:
+    - 'My View'
+  jobs:
+    - '.*'
+
+#-----------------------------------------------------------------------------
 # Method for writing tags and marking the build as created by jenkins-autojobs.
 #   'description' -> add special strings to the job's description (default).
 #   'element'     -> add new xml elements to the job's config.xml.

--- a/docs/examples/hg-config.yaml.jinja2
+++ b/docs/examples/hg-config.yaml.jinja2
@@ -80,4 +80,6 @@ refs:
 
 {{ m.cleanup()|trim }}
 
+{{ m.cleanup_filter()|trim }}
+
 {{ m.tag_method()|trim }}

--- a/docs/examples/shared-config.jinja2
+++ b/docs/examples/shared-config.jinja2
@@ -106,3 +106,18 @@ view: 'view-name'
 # don’t want them to mutually cleanup each others jobs.
 cleanup: true  # or 'throw-away-jobs'
 {% endmacro %}
+
+{% macro cleanup_filter() %}
+#-----------------------------------------------------------------------------
+# Filter jobs by views and job names. By default all jobs are checked if they
+# should be removed. To reduce time you can filter which jobs should be
+# checked. You can use:
+# 1. List of views, by default jobs from all views are taken.
+# 2. List of job names as regular expressions, by default all jobs will be
+# taken.
+cleanup-filters:
+  views:
+    - 'My View'
+  jobs:
+    - '.*'
+{% endmacro %}

--- a/docs/examples/svn-config.yaml
+++ b/docs/examples/svn-config.yaml
@@ -126,6 +126,19 @@ tag: 'throw-away-jobs'
 cleanup: true  # or 'throw-away-jobs'
 
 #-----------------------------------------------------------------------------
+# Filter jobs by views and job names. By default all jobs are checked if they
+# should be removed. To reduce time you can filter which jobs should be
+# checked. You can use:
+# 1. List of views, by default jobs from all views are taken.
+# 2. List of job names as regular expressions, by default all jobs will be
+# taken.
+cleanup-filters:
+  views:
+    - 'My View'
+  jobs:
+    - '.*'
+
+#-----------------------------------------------------------------------------
 # Method for writing tags and marking the build as created by jenkins-autojobs.
 #   'description' -> add special strings to the job's description (default).
 #   'element'     -> add new xml elements to the job's config.xml.

--- a/docs/examples/svn-config.yaml.jinja2
+++ b/docs/examples/svn-config.yaml.jinja2
@@ -74,4 +74,6 @@ refs:
 
 {{ m.cleanup()|trim }}
 
+{{ m.cleanup_filter()|trim }}
+
 {{ m.tag_method()|trim }}

--- a/jenkins_autojobs/main.py
+++ b/jenkins_autojobs/main.py
@@ -185,6 +185,8 @@ def cleanup(config, created_job_names, jenkins, verbose=True):
         if isinstance(config['cleanup'], str):
             clean_tags = get_autojobs_tags(job_config, config['tag-method'])
             if not config['cleanup'] in clean_tags:
+                if config['debug']:
+                    print('. skipping %s' % job.name)
                 continue
 
         removed_jobs.append(job)
@@ -237,10 +239,12 @@ def get_managed_jobs(config, created_job_names, jenkins, safe_codes=(403,)):
         jobs = filtrated_jobs
 
     # Returns managed jobs to remove.
-    # It returns jobs which were not created or updated
+    # It returns jobs which were not just created or updated
     # and have 'tag' in configuration.
     for job in jobs:
         if job.name in created_job_names:
+            if config['debug']:
+                print('. skipping %s' % job.name)
             continue
         try:
             job_config = job.config

--- a/jenkins_autojobs/main.py
+++ b/jenkins_autojobs/main.py
@@ -180,7 +180,7 @@ def cleanup(config, created_job_names, jenkins, verbose=True):
 
     removed_jobs = []
 
-    for job, job_config in get_managed_jobs(created_job_names, jenkins):
+    for job, job_config in get_managed_jobs(config, created_job_names, jenkins):
         # If cleanup is a tag name, only cleanup builds with that tag.
         if isinstance(config['cleanup'], str):
             clean_tags = get_autojobs_tags(job_config, config['tag-method'])
@@ -214,11 +214,32 @@ def get_autojobs_tags(job_config, method):
     tags = tags[0].split() if tags else []
     return tags
 
-def get_managed_jobs(created_job_names, jenkins, safe_codes=(403,)):
+def get_managed_jobs(config, created_job_names, jenkins, safe_codes=(403,)):
     tag_el = '</createdByJenkinsAutojobs>'
     tag_desc = '(created by jenkins-autojobs)'
 
-    for job in jenkins.jobs:
+    # Get only jobs only from filtrated views.
+    if len(config['cleanup-filters']['views']) == 0:
+        jobs = set(jenkins.jobs)
+    else:
+        jobs = set()
+        for v in config['cleanup-filters']['views']:
+            jobs = jobs.union(set(jenkins.view(v).jobs))
+
+    # Filter jobs by regular expressions.
+    if len(config['cleanup-filters']['jobs']) != 0:
+        filtrated_jobs = set()
+        for j in jobs:
+            for r in config['cleanup-filters']['jobs']:
+                if r.match(j.name):
+                    filtrated_jobs.add(j)
+                    break
+        jobs = filtrated_jobs
+
+    # Returns managed jobs to remove.
+    # It returns jobs which were not created or updated
+    # and have 'tag' in configuration.
+    for job in jobs:
         if job.name in created_job_names:
             continue
         try:
@@ -266,6 +287,7 @@ def get_default_config(config, opts):
     c['scm-username'] = config.get('scm-username', None)
     c['scm-password'] = config.get('scm-password', None)
     c['tag-method'] = config.get('tag-method', 'element')
+    c['cleanup-filters'] = config.get('cleanup-filters', {})
 
     # Default settings for each git ref/branch config.
     c['defaults'] = {
@@ -280,6 +302,10 @@ def get_default_config(config, opts):
         'view':            c.get('view', []),
         'build-on-create': c.get('build-on-create', False)
     }
+
+    # Defaults settings for cleanup filters.
+    c['cleanup-filters']['views'] = c['cleanup-filters'].get('views', [])
+    c['cleanup-filters']['jobs'] = c['cleanup-filters'].get('jobs', [])
 
     # Make sure some options are always lists.
     c['defaults']['view'] = utils.pluralize(c['defaults']['view'])
@@ -306,6 +332,14 @@ def get_default_config(config, opts):
     # Compile ignore regexes.
     c.setdefault('ignore', {})
     c['ignore'] = [re.compile(i) for i in c['ignore']]
+
+    # Compile cleanup filters jobs regexes.
+    c['cleanup-filters']['jobs'] = [re.compile(i) for i in c['cleanup-filters']['jobs']]
+
+    # The 'All' view doesn't have an API endpoint (i.e. no /view/All/api).
+    # Since all jobs are added to it by default, we can ignore all other views.
+    if 'All' in c['cleanup-filters']['views']:
+        c['cleanup-filters']['views'] = []
 
     if 'refs' not in c:
         c['refs'] = ['.*']


### PR DESCRIPTION
During cleanup, `jenkins-autojobs` checks configuration of all jobs in the Jenkins instance. If the Jenkins has a lot of jobs, like few hundreds, it will take some time to check all jobs. By using `cleanup-filters` user can select which jobs (by view or job name) should be checked.