### PR TITLE
git script: correct erased branch substitution

### DIFF
--- a/jenkins_autojobs/git.py
+++ b/jenkins_autojobs/git.py
@@ -99,7 +99,7 @@ def create_job(ref, template, config, ref_config):
 
     # If el.text is not empty, the template has already had a treeish specified
     # do not erase it
-    if not el.text:
+    if not ref_config['ignore-jobs']:
 	# :todo: jenkins is being very capricious about the branch-spec
 	# el.text = '%s/%s' % (remote, shortref)  # :todo:
 	el.text = shortref

--- a/jenkins_autojobs/git.py
+++ b/jenkins_autojobs/git.py
@@ -96,15 +96,18 @@ def create_job(ref, template, config, ref_config):
 
     # Set branch.
     el = scm_el.xpath('//hudson.plugins.git.BranchSpec/name')[0]
-    # :todo: jenkins is being very capricious about the branch-spec
-    # el.text = '%s/%s' % (remote, shortref)  # :todo:
-    el.text = shortref
 
-    # Set the branch that the git plugin will locally checkout to.
-    el = scm_el.xpath('//localBranch')
-    el = lxml.etree.SubElement(scm_el, 'localBranch') if not el else el[0]
+    # If el.text is not empty, the template has already had a treeish specified
+    # do not erase it
+    if not el.text:
+	# :todo: jenkins is being very capricious about the branch-spec
+	# el.text = '%s/%s' % (remote, shortref)  # :todo:
+	el.text = shortref
 
-    el.text = shortref  # the original shortref (with '/')
+	# Set the branch that the git plugin will locally checkout to.
+	el = scm_el.xpath('//localBranch')
+	el = lxml.etree.SubElement(scm_el, 'localBranch') if not el else el[0]
+	el.text = shortref  # the original shortref (with '/')
 
     # Set the state of the newly created job.
     job_obj.set_state(ref_config['enable'])


### PR DESCRIPTION
During the extraction of a job configuration, the substitution of variables
is done before git script starts looking for existing branches in the git repo.
If the template has already a branch or a commit specified, it is automatically
erased without checking.

This commit checks if such a treeish exists and avoid erasing it.
