### PR TITLE
Fix example for cleanup-filters in changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,10 +47,10 @@ Version 0.17.1 was skipped because of a failed upload to PyPi (see `issue #74`_)
       # Cleanup only jobs in the 'Feature' and 'Release' views as well as all
       jobs that start with 'scratch'.
       cleanup-filters:
-        - views:
+        views:
           - Feature
           - Release
-        - name:
+        name:
           - '^scratch-.*'
 
 - Added the ``list-closed`` option to the mercurial plugin, which controls the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,8 +48,8 @@ Version 0.17.1 was skipped because of a failed upload to PyPi (see `issue #74`_)
       jobs that start with 'scratch'.
       cleanup-filters:
         views:
-          - Feature
-          - Release
+          - 'Feature'
+          - 'Release'
         name:
           - '^scratch-.*'
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,7 +50,7 @@ Version 0.17.1 was skipped because of a failed upload to PyPi (see `issue #74`_)
         views:
           - 'Feature'
           - 'Release'
-        name:
+        jobs:
           - '^scratch-.*'
 
 - Added the ``list-closed`` option to the mercurial plugin, which controls the


### PR DESCRIPTION
- cleanup-filters must be a list.
- `jobs` is expected instead of `name`
- views names must be strings