### PR TITLE
Fix warning with Python 3.4

### DIFF
--- a/jenkins_autojobs/main.py
+++ b/jenkins_autojobs/main.py
@@ -121,7 +121,7 @@ def main(argv, create_job, list_branches, config=None):
     # Load config, set default values and compile regexes.
     if not config:
         print('loading config from "%s"' % os.path.abspath(opts.yamlconfig.name))
-        config = yaml.load(opts.yamlconfig)
+        config = yaml.load(opts.yamlconfig, Loader=yaml.Loader)
 
     config = c = get_default_config(config, opts)
 


### PR DESCRIPTION
Warning showing up while running with Python 3.4

> /usr/local/lib/python3.4/site-packages/jenkins_autojobs/main.py:124: UnsafeLoaderWarning:
> The default 'Loader' for 'load(stream)' without further arguments can be unsafe.
> Use 'load(stream, Loader=ruamel.yaml.Loader)' explicitly if that is OK.
> Alternatively include the following in your code:
> 
>   import warnings
>   warnings.simplefilter('ignore', ruamel.yaml.error.UnsafeLoaderWarning)
> 
> In most other cases you should consider using 'safe_load(stream)'
>   config = yaml.load(opts.yamlconfig)